### PR TITLE
Allow disabling default show index mappings

### DIFF
--- a/doc/indexedsearch.txt
+++ b/doc/indexedsearch.txt
@@ -29,6 +29,7 @@ Checking At which Match Number You Are
 You can also press g/ or \\ or \/ (that's backslach then slash), it's the same
 as running :ShowSearchIndex, to show at which match index you are, without moving 
 the cursor. 
+To disable these mappings, set 'let g:indexed_search_show_index_mappings=0'
 
 Messages are: >
     At Nth match of M (if cursor is exactly on the match) 

--- a/plugin/IndexedSearch.vim
+++ b/plugin/IndexedSearch.vim
@@ -102,9 +102,15 @@ endif
 nnoremap <silent># :let v:errmsg=''<cr>:silent! norm! #<cr>:call <SID>ShowCurrentSearchIndex(0,'!')<cr>
 
 
-nnoremap <silent>\/        :call <SID>ShowCurrentSearchIndex(1,'')<cr>
-nnoremap <silent>\\        :call <SID>ShowCurrentSearchIndex(1,'')<cr>
-nnoremap <silent>g/        :call <SID>ShowCurrentSearchIndex(1,'')<cr>
+if !exists("g:indexed_search_show_index_mappings")
+  let g:indexed_search_show_index_mappings=1
+endif
+
+if g:indexed_search_show_index_mappings
+  nnoremap <silent>\/        :call <SID>ShowCurrentSearchIndex(1,'')<cr>
+  nnoremap <silent>\\        :call <SID>ShowCurrentSearchIndex(1,'')<cr>
+  nnoremap <silent>g/        :call <SID>ShowCurrentSearchIndex(1,'')<cr>
+endif
 
 
 " before 061120,  I had cmapping for <cr> which was very intrusive. Didn't work


### PR DESCRIPTION
By setting `g:indexed_search_show_index_mappings=0`. This helps prevent conflicts and is (IMO) better than the user having to unmap a bunch of things.
