### PR TITLE
use nmap for / and ?

### DIFF
--- a/plugin/IndexedSearch.vim
+++ b/plugin/IndexedSearch.vim
@@ -116,8 +116,8 @@ endif
 "                 with supertab iInde<c-x><c-p>(resulted in something like recursive <c-r>=
 " after  061120,  I remap [/?] instead of remapping <cr>. Works in vim6, too
 
-nnoremap / :call <SID>DelaySearchIndex(0,'')<cr>/
-nnoremap ? :call <SID>DelaySearchIndex(0,'')<cr>?
+nmap / :call <SID>DelaySearchIndex(0,'')<cr>/
+nmap ? :call <SID>DelaySearchIndex(0,'')<cr>?
 
 
 let s:ScheduledEcho = ''


### PR DESCRIPTION
So, I have [this plugin](https://github.com/exvim/ex-searchcompl) that I want to try out and it also maps `/` (using nmap).
