### PR TITLE
Fixed helptags error

### DIFF
--- a/doc/indexedsearch.txt
+++ b/doc/indexedsearch.txt
@@ -85,7 +85,7 @@ PERFORMANCE                                     *indexed-search-performance*
 
 Plugin bypasses the calculation of match index when it would take too much
 time (too many matches, too large file).  To tune these performance limits,
-see *g:indexed_search_max_lines* and *g:indexed_search_max_hits*
+see |g:indexed_search_max_lines| and |g:indexed_search_max_hits|
 
 
 vim:tw=78:ts=8:ft=help:norl:


### PR DESCRIPTION
Hey - helptags generation fails currently on duplicate tags (g:indexed_search_max_lines and g:indexed_search_max_hits). This fixes it and changes the line to be a reference to the section.