### PR TITLE
Prevent empty statusline (MacVim)

### DIFF
--- a/autoload/indexed_search.vim
+++ b/autoload/indexed_search.vim
@@ -12,6 +12,7 @@ endfunction
 
 function! s:colored_echo(msg, hl)
     execute "echohl ". a:hl
+    redraw
     echo a:msg
     echohl None
 endfunction


### PR DESCRIPTION
The statusline is blank when I invoke and increment through search from MacVim. In terminal vim, works great. I pruned down my `.vimrc` but still ran into the issue. Not sure if this is the best fix, but the `redraw` command has been working well for me.

[My MacVim version](https://gist.github.com/youngjames/9253841151b7a248555a)