### PR TITLE
Add option to define default search direction

### DIFF
--- a/doc/indexedsearch.txt
+++ b/doc/indexedsearch.txt
@@ -88,6 +88,14 @@ g:indexed_search_numbered_only
                 "First of" and "Last of".
                 Default: 0
 
+                                                *g:indexed_search_n_always_searches_forward*
+g:indexed_search_n_always_searches_forward
+                In vim, by default, the direction of n and N depends on
+                whether / or ? was used for searching forward or backward
+                respectively.
+                If 1, n always search forward and N backward
+                Default: 1
+
 =============================================================================
 MAPPINGS                                        *indexed-search-mappings*
 

--- a/plugin/IndexedSearch.vim
+++ b/plugin/IndexedSearch.vim
@@ -88,6 +88,10 @@ if !exists('g:indexed_search_line_info')
   let g:indexed_search_line_info = 0
 endif
 
+if !exists('g:indexed_search_n_always_searches_forward')
+  let g:indexed_search_n_always_searches_forward = 1
+endif
+
 
 command! -bang ShowSearchIndex :call indexed_search#show_index(<bang>0)
 
@@ -97,8 +101,15 @@ noremap <Plug>(indexed-search-?)  :ShowSearchIndex<CR>?
 noremap <silent> <Plug>(indexed-search-*)  *:ShowSearchIndex<CR>
 noremap <silent> <Plug>(indexed-search-#)  #:ShowSearchIndex<CR>
 
-noremap <silent> <Plug>(indexed-search-n)  n:ShowSearchIndex<CR>
-noremap <silent> <Plug>(indexed-search-N)  N:ShowSearchIndex<CR>
+if g:indexed_search_n_always_searches_forward
+    noremap <silent><expr> <Plug>(indexed-search-n) 'Nn'[v:searchforward] . ':ShowSearchIndex<CR>'
+    noremap <silent><expr> <Plug>(indexed-search-N) 'nN'[v:searchforward] . ':ShowSearchIndex<CR>'
+else
+    noremap <silent> <Plug>(indexed-search-n)  n:ShowSearchIndex<CR>
+    noremap <silent> <Plug>(indexed-search-N)  N:ShowSearchIndex<CR>
+end
+
+
 
 if g:indexed_search_mappings
     nmap / <Plug>(indexed-search-/)


### PR DESCRIPTION
See:
https://github.com/mhinz/vim-galore#saner-behavior-of-n-and-n

I have that mappings on my vimrc configuration. I think it should be the default vim behavior, that's why I suggest to enable the option by default.